### PR TITLE
Simple throttling support

### DIFF
--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -69,7 +69,7 @@ def send_all():
     logging.debug("acquired.")
     
     start_time = time.time()
-    send_delay = SEND_RATE and 1.0 / SEND_RATE
+    send_delay = max(0, SEND_RATE and 1.0 / SEND_RATE or 0)
     
     dont_send = 0
     deferred = 0

--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -28,6 +28,9 @@ LOCK_WAIT_TIMEOUT = getattr(settings, "MAILER_LOCK_WAIT_TIMEOUT", -1)
 # The actual backend to use for sending, defaulting to the Django default.
 EMAIL_BACKEND = getattr(settings, "MAILER_EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend")
 
+# How many messages can be sent each second
+SEND_RATE = getattr(settings, "MAILER_SEND_RATE", None)
+
 
 def prioritize():
     """
@@ -66,6 +69,7 @@ def send_all():
     logging.debug("acquired.")
     
     start_time = time.time()
+    send_delay = SEND_RATE and 1.0 / SEND_RATE
     
     dont_send = 0
     deferred = 0
@@ -74,6 +78,8 @@ def send_all():
     try:
         connection = None
         for message in prioritize():
+            if send_delay and sent:
+                time.sleep(send_delay)
             try:
                 if connection is None:
                     connection = get_connection(backend=EMAIL_BACKEND)


### PR DESCRIPTION
Added support to supply a send rate in the settings file to limit the number of messages sent per second.  By default, no throttling will occur.  Throttling can be enabled by setting MAILER_SEND_RATE to the number of messages that may be sent per second.  For instance, setting MAILER_SEND_RATE to 1 will limit sending to 1 message per second, 10 will limit to 10 messages per second, and 0.1666 (1/6) will limit to 1 message about every 6 seconds.  Omitting MAILER_SEND_RATE or setting it to zero, None, or a negative value will disable throttling.

This changeset does not take into account the time it takes to send a message, it only calculates a simple delay between sends.