### PR TITLE
Added support to delay sending of messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/*
+*.pyc
+*egg-info/

--- a/mailer/__init__.py
+++ b/mailer/__init__.py
@@ -28,7 +28,8 @@ PRIORITY_MAPPING = {
 
 
 def send_mail(subject, message, from_email, recipient_list, priority="medium",
-              fail_silently=False, auth_user=None, auth_password=None):
+              sending_delay=None, fail_silently=False, auth_user=None,
+              auth_password=None):
     from django.utils.encoding import force_unicode
     from mailer.models import make_message
     
@@ -42,13 +43,14 @@ def send_mail(subject, message, from_email, recipient_list, priority="medium",
                  body=message,
                  from_email=from_email,
                  to=recipient_list,
-                 priority=priority).save()
+                 priority=priority,
+                 sending_delay=sending_delay).save()
     return 1
 
 
 def send_html_mail(subject, message, message_html, from_email, recipient_list,
-                   priority="medium", fail_silently=False, auth_user=None,
-                   auth_password=None):
+                   priority="medium", sending_delay=None, fail_silently=False,
+                   auth_user=None, auth_password=None):
     """
     Function to queue HTML e-mails
     """
@@ -66,7 +68,8 @@ def send_html_mail(subject, message, message_html, from_email, recipient_list,
                        body=message,
                        from_email=from_email,
                        to=recipient_list,
-                       priority=priority)
+                       priority=priority,
+                       sending_delay=sending_delay)
     email = msg.email
     email = EmailMultiAlternatives(email.subject, email.body, email.from_email, email.to)
     email.attach_alternative(message_html, "text/html")

--- a/mailer/admin.py
+++ b/mailer/admin.py
@@ -4,7 +4,7 @@ from mailer.models import Message, DontSendEntry, MessageLog
 
 
 class MessageAdmin(admin.ModelAdmin):
-    list_display = ["id", "to_addresses", "subject", "when_added", "priority"]
+    list_display = ["id", "to_addresses", "subject", "when_added", "when_send", "priority"]
 
 
 class DontSendEntryAdmin(admin.ModelAdmin):

--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -35,15 +35,15 @@ def prioritize():
     """
     
     while True:
-        while Message.objects.high_priority().count() or Message.objects.medium_priority().count():
-            while Message.objects.high_priority().count():
-                for message in Message.objects.high_priority().order_by("when_added"):
+        while Message.objects_to_send.high_priority().count() or Message.objects_to_send.medium_priority().count():
+            while Message.objects_to_send.high_priority().count():
+                for message in Message.objects_to_send.high_priority().order_by("when_added"):
                     yield message
-            while Message.objects.high_priority().count() == 0 and Message.objects.medium_priority().count():
-                yield Message.objects.medium_priority().order_by("when_added")[0]
-        while Message.objects.high_priority().count() == 0 and Message.objects.medium_priority().count() == 0 and Message.objects.low_priority().count():
-            yield Message.objects.low_priority().order_by("when_added")[0]
-        if Message.objects.non_deferred().count() == 0:
+            while Message.objects_to_send.high_priority().count() == 0 and Message.objects_to_send.medium_priority().count():
+                yield Message.objects_to_send.medium_priority().order_by("when_added")[0]
+        while Message.objects_to_send.high_priority().count() == 0 and Message.objects_to_send.medium_priority().count() == 0 and Message.objects_to_send.low_priority().count():
+            yield Message.objects_to_send.low_priority().order_by("when_added")[0]
+        if Message.objects_to_send.non_deferred().count() == 0:
             break
 
 

--- a/mailer/migrations/0001_initial.py
+++ b/mailer/migrations/0001_initial.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Message'
+        db.create_table('mailer_message', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('message_data', self.gf('django.db.models.fields.TextField')()),
+            ('when_added', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('priority', self.gf('django.db.models.fields.CharField')(default='2', max_length=1)),
+        ))
+        db.send_create_signal('mailer', ['Message'])
+
+        # Adding model 'DontSendEntry'
+        db.create_table('mailer_dontsendentry', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('to_address', self.gf('django.db.models.fields.EmailField')(max_length=75)),
+            ('when_added', self.gf('django.db.models.fields.DateTimeField')()),
+        ))
+        db.send_create_signal('mailer', ['DontSendEntry'])
+
+        # Adding model 'MessageLog'
+        db.create_table('mailer_messagelog', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('message_data', self.gf('django.db.models.fields.TextField')()),
+            ('when_added', self.gf('django.db.models.fields.DateTimeField')()),
+            ('priority', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('when_attempted', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('result', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('log_message', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('mailer', ['MessageLog'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Message'
+        db.delete_table('mailer_message')
+
+        # Deleting model 'DontSendEntry'
+        db.delete_table('mailer_dontsendentry')
+
+        # Deleting model 'MessageLog'
+        db.delete_table('mailer_messagelog')
+
+
+    models = {
+        'mailer.dontsendentry': {
+            'Meta': {'object_name': 'DontSendEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_address': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'mailer.message': {
+            'Meta': {'object_name': 'Message'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '1'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        'mailer.messagelog': {
+            'Meta': {'object_name': 'MessageLog'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'log_message': ('django.db.models.fields.TextField', [], {}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'result': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {}),
+            'when_attempted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        }
+    }
+
+    complete_apps = ['mailer']

--- a/mailer/migrations/0002_auto__add_field_message_sending_delay.py
+++ b/mailer/migrations/0002_auto__add_field_message_sending_delay.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Message.sending_delay'
+        db.add_column('mailer_message', 'sending_delay',
+                      self.gf('django.db.models.fields.PositiveIntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Message.sending_delay'
+        db.delete_column('mailer_message', 'sending_delay')
+
+
+    models = {
+        'mailer.dontsendentry': {
+            'Meta': {'object_name': 'DontSendEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_address': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'mailer.message': {
+            'Meta': {'object_name': 'Message'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '1'}),
+            'sending_delay': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        },
+        'mailer.messagelog': {
+            'Meta': {'object_name': 'MessageLog'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'log_message': ('django.db.models.fields.TextField', [], {}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'result': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {}),
+            'when_attempted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        }
+    }
+
+    complete_apps = ['mailer']

--- a/mailer/migrations/0003_auto__add_field_message_when_send.py
+++ b/mailer/migrations/0003_auto__add_field_message_when_send.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Message.when_send'
+        db.add_column('mailer_message', 'when_send',
+                      self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime(2013, 1, 4, 0, 0)),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Message.when_send'
+        db.delete_column('mailer_message', 'when_send')
+
+
+    models = {
+        'mailer.dontsendentry': {
+            'Meta': {'object_name': 'DontSendEntry'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_address': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'mailer.message': {
+            'Meta': {'object_name': 'Message'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'default': "'2'", 'max_length': '1'}),
+            'sending_delay': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'when_send': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'mailer.messagelog': {
+            'Meta': {'object_name': 'MessageLog'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'log_message': ('django.db.models.fields.TextField', [], {}),
+            'message_data': ('django.db.models.fields.TextField', [], {}),
+            'priority': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'result': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'when_added': ('django.db.models.fields.DateTimeField', [], {}),
+            'when_attempted': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'})
+        }
+    }
+
+    complete_apps = ['mailer']


### PR DESCRIPTION
Motivation
========
In some scenarios could be needed to wait some time before to send some messages.

Solution
=======
At the moment of adding a message to the queue, now you can specify an optional value of `sending delay`. which will be considered when the messages are sent by the management command `send_mail`

Other changes
============
* unversioned *.pyc, .idea/*, *egg-info/
* generated south migrations
