### PR TITLE
Allow finer control of message delivery

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,3 +94,36 @@ details.
 
 .. _pinax documentation: http://pinaxproject.com/docs/dev/deployment.html#sending-mail-and-notices
 
+===================
+Using EMAIL_BACKEND
+===================
+
+To automatically switch all your mail to use django-mailer, instead of changing imports
+you can also use the EMAIL_BACKEND feature that was introduced in Django 1.2. In
+your settings file, you first have to set EMAIL_BACKEND::
+
+    EMAIL_BACKEND = "mailer.backend.DbBackend"
+
+If you were previously using a non-default EMAIL_BACKEND, you need to configure
+the MAILER_EMAIL_BACKEND setting, so that django-mailer knows how to actually send
+the mail::
+
+    MAILER_EMAIL_BACKEND = "your.actual.EmailBackend"
+
+Controlling the delivery process
+================================
+
+If you wish to have a finer control over the delivery process, which defaults
+to deliver everything in the queue, you can use the following 3 variables
+(default values shown)::
+
+    MAILER_EMAIL_MAX_BATCH = None  # integer or None
+    MAILER_EMAIL_MAX_DEFERRED = None  # integer or None
+    MAILER_EMAIL_THROTTLE = 0  # passed to time.sleep()
+
+These control how many emails are sent successfully before stopping the
+current run `MAILER_EMAIL_MAX_BATCH`, after how many failed/deferred emails
+should it stop `MAILER_EMAIL_MAX_DEFERRED` and how much time to wait between
+each email `MAILER_EMAIL_THROTTLE`.
+
+Unprocessed emails will be evaluated in the following delivery iterations.

--- a/mailer/tests.py
+++ b/mailer/tests.py
@@ -11,6 +11,7 @@ from mock import patch, Mock
 import pickle
 import lockfile
 import smtplib
+import time
 
 
 class TestMailerEmailBackend(object):
@@ -46,6 +47,10 @@ class TestBackend(TestCase):
 
 
 class TestSending(TestCase):
+    def setUp(self):
+        # Ensure outbox is empty at start
+        del TestMailerEmailBackend.outbox[:]
+
     def test_mailer_email_backend(self):
         """
         Test that calling "manage.py send_mail" actually sends mail using the
@@ -205,6 +210,80 @@ class TestSending(TestCase):
             # Default "plain text"
             self.assertEqual(sent.body, "GoBody")
             self.assertEqual(sent.to, ["go@example.com"])
+
+    def test_control_max_delivery_amount(self):
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.TestMailerEmailBackend", MAILER_EMAIL_MAX_BATCH=2):  # noqa
+            mailer.send_mail("Subject1", "Body1", "sender1@example.com", ["recipient1@example.com"])
+            mailer.send_mail("Subject2", "Body2", "sender2@example.com", ["recipient2@example.com"])
+            mailer.send_mail("Subject3", "Body3", "sender3@example.com", ["recipient3@example.com"])
+            self.assertEqual(Message.objects.count(), 3)
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 0)
+            engine.send_all()
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 2)
+            self.assertEqual(Message.objects.count(), 1)
+            self.assertEqual(MessageLog.objects.count(), 2)
+
+    def test_control_max_retry_amount(self):
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.TestMailerEmailBackend"):  # noqa
+            # 5 normal emails scheduled for delivery
+            mailer.send_mail("Subject1", "Body1", "sender1@example.com", ["recipient1@example.com"])
+            mailer.send_mail("Subject2", "Body2", "sender2@example.com", ["recipient2@example.com"])
+            mailer.send_mail("Subject3", "Body3", "sender3@example.com", ["recipient3@example.com"])
+            mailer.send_mail("Subject4", "Body4", "sender4@example.com", ["recipient4@example.com"])
+            mailer.send_mail("Subject5", "Body5", "sender5@example.com", ["recipient5@example.com"])
+            self.assertEqual(Message.objects.count(), 5)
+            self.assertEqual(Message.objects.deferred().count(), 0)
+
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.FailingMailerEmailBackend", MAILER_EMAIL_MAX_DEFERRED=2):  # noqa
+            # 2 will get deferred 3 remain undeferred
+            engine.send_all()
+            self.assertEqual(Message.objects.count(), 5)
+            self.assertEqual(Message.objects.deferred().count(), 2)
+
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.TestMailerEmailBackend", MAILER_EMAIL_MAX_DEFERRED=2):  # noqa
+            # 3 will be delivered, 2 remain deferred
+            engine.send_all()
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 3)
+            # Should not have sent the deferred ones
+            self.assertEqual(Message.objects.count(), 2)
+            self.assertEqual(Message.objects.deferred().count(), 2)
+
+            # Now mark them for retrying
+            Message.objects.retry_deferred()
+            engine.send_all()
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 2)
+            self.assertEqual(Message.objects.count(), 0)
+
+    def test_throttling_delivery(self):
+        TIME = 1  # throttle time = 1 second
+
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.TestMailerEmailBackend"):
+            # Calculate how long it takes to deliver 2 messages without throttling
+            mailer.send_mail("Subject", "Body", "sender11@example.com", ["recipient@example.com"])
+            mailer.send_mail("Subject", "Body", "sender12@example.com", ["recipient@example.com"])
+            # 3 will be delivered, 2 remain deferred
+            start_time = time.time()
+            engine.send_all()
+            unthrottled_time = time.time() - start_time
+
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 2)
+            self.assertEqual(Message.objects.count(), 0)
+
+        with self.settings(MAILER_EMAIL_BACKEND="mailer.tests.TestMailerEmailBackend", MAILER_EMAIL_THROTTLE=TIME):  # noqa
+            mailer.send_mail("Subject", "Body", "sender13@example.com", ["recipient@example.com"])
+            mailer.send_mail("Subject", "Body", "sender14@example.com", ["recipient@example.com"])
+            # 3 will be delivered, 2 remain deferred
+            start_time = time.time()
+            engine.send_all()
+            throttled_time = time.time() - start_time
+
+            self.assertEqual(len(TestMailerEmailBackend.outbox), 2)
+            self.assertEqual(Message.objects.count(), 0)
+
+        # NOTE This is a bit tricky to test due to possible fluctuations on
+        # execution time. Test may randomly fail
+        # NOTE 2*TIME because 2 emails are sent during the test
+        self.assertAlmostEqual(unthrottled_time, throttled_time - 2*TIME, places=1)
 
 
 class TestLockNormal(TestCase):


### PR DESCRIPTION
These extra variables allow tweaking the delivery process to help balance the load of delivery on the server and prevent situations where messages keep getting deferred due to excess requests.

The default values ensure the same behaviour as before.