### PR TITLE
Ignore MANIFEST and .coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .tox
+MANIFEST
+.coverage


### PR DESCRIPTION
Ignore MANIFEST and .coverage files. These are created during the tox setup.