### PR TITLE
Fix minor documentation syntax

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -77,7 +77,7 @@ You may want to set these up via cron to run regularly::
     *       * * * * (/path/to/your/python /path/to/your/manage.py send_mail >> ~/cron_mail.log 2>&1)
     0,20,40 * * * * (/path/to/your/python /path/to/your/manage.py retry_deferred >> ~/cron_mail_deferred.log 2>&1)
 
-For use in Pinax, for example, that might look like:
+For use in Pinax, for example, that might look like::
 
     * * * * * (cd $PINAX; /usr/local/bin/python2.5 manage.py send_mail >> $PINAX/cron_mail.log 2>&1)
     0,20,40 * * * * (cd $PINAX; /usr/local/bin/python2.5 manage.py retry_deferred >> $PINAX/cron_mail_deferred.log 2>&1)


### PR DESCRIPTION
The small typo is causing bad formatting when converted to HTML.