### PR TITLE
Silence test warnings

### DIFF
--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -118,7 +118,7 @@ def send_all():
                     MessageLog.objects.log(message, 1)  # @@@ avoid using literal result code
                     sent += 1
                 else:
-                    logging.warn("message discarded due to failure in converting from DB. Added on '%s' with priority '%s'" % (message.when_added, message.priority))  # noqa
+                    logging.warning("message discarded due to failure in converting from DB. Added on '%s' with priority '%s'" % (message.when_added, message.priority))  # noqa
                 message.delete()
 
             except (socket_error, smtplib.SMTPSenderRefused, smtplib.SMTPRecipientsRefused, smtplib.SMTPAuthenticationError) as err:  # noqa


### PR DESCRIPTION
A few logging and deprecation warnings were being printed to the terminal when tests are executing.

This pull request corrects the deprecated code and silences the logging warnings while ensuring they are issued under expected circumstances.