### PR TITLE
Explicitly set email length to ensure compatibility with Django 1.7

### DIFF
--- a/mailer/models.py
+++ b/mailer/models.py
@@ -207,7 +207,7 @@ class DontSendEntryManager(models.Manager):
 
 class DontSendEntry(models.Model):
 
-    to_address = models.EmailField()
+    to_address = models.EmailField(max_length=254)
     when_added = models.DateTimeField()
     # @@@ who added?
     # @@@ comment field?


### PR DESCRIPTION
Django 1.8 increases default max_length of EmailField from 75 to 254. Since max_length is not currently specified, but the initial migration contains the 1.8 default of 254, Django 1.7 will think there's a migration to create, decreasing the max_length to 75. This can be fixed by explicitly setting the max_length to 254.