### PR TITLE
switch commands to argparse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - TOXENV=py33-django16-test
   - TOXENV=py33-django17-test
   - TOXENV=py33-django18-test
-  - TOXENV=py33-django19-test
   - TOXENV=py34-django16-test
   - TOXENV=py34-django17-test
   - TOXENV=py34-django18-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,16 @@ env:
   - TOXENV=py27-django16-test
   - TOXENV=py27-django17-test
   - TOXENV=py27-django18-test
+  - TOXENV=py27-django19-test
   - TOXENV=py33-django15-test
   - TOXENV=py33-django16-test
   - TOXENV=py33-django17-test
   - TOXENV=py33-django18-test
+  - TOXENV=py33-django19-test
   - TOXENV=py34-django16-test
   - TOXENV=py34-django17-test
   - TOXENV=py34-django18-test
+  - TOXENV=py34-django19-test
   - TOXENV=py27-flake
   - TOXENV=py33-flake
   - TOXENV=py34-flake

--- a/mailer/management/commands/retry_deferred.py
+++ b/mailer/management/commands/retry_deferred.py
@@ -5,14 +5,11 @@ from django.core.management.base import NoArgsCommand
 from django.db import connection
 
 from mailer.models import Message
+from mailer.management.helpers import CronArgMixin
 
 
-class Command(NoArgsCommand):
+class Command(CronArgMixin, NoArgsCommand):
     help = "Attempt to resend any deferred mail."
-    base_options = (
-        make_option('-c', '--cron', default=0, type='int', help='If 1 don\'t print messagges, but only errors.'),  # noqa
-    )
-    option_list = NoArgsCommand.option_list + base_options
 
     def handle_noargs(self, **options):
         if options['cron'] == 0:

--- a/mailer/management/commands/retry_deferred.py
+++ b/mailer/management/commands/retry_deferred.py
@@ -1,5 +1,4 @@
 import logging
-from optparse import make_option
 
 from django.core.management.base import NoArgsCommand
 from django.db import connection

--- a/mailer/management/commands/send_mail.py
+++ b/mailer/management/commands/send_mail.py
@@ -6,35 +6,14 @@ from django.core.management.base import NoArgsCommand
 from django.db import connection
 
 from mailer.engine import send_all
+from mailer.management.helpers import CronArgMixin
 
 
 # allow a sysadmin to pause the sending of mail temporarily.
 PAUSE_SEND = getattr(settings, "MAILER_PAUSE_SEND", False)
 
-help_msg = "If 1 don't print messagges, but only errors."
 
-
-if NoArgsCommand.option_list:
-    # old; optparse
-    class ArgsMixin(object):
-        base_options = (
-            make_option('-c', '--cron', default=0, type='int', help=help_msg),
-        )
-        option_list = NoArgsCommand.option_list + base_options
-else:
-    # new; argparse
-    class ArgsMixin(object):
-        def add_arguments(self, parser):
-            parser.add_argument(
-                '-c',
-                '--cron',
-                default=0,
-                type=int,
-                help=help_msg,
-            )
-
-
-class Command(ArgsMixin, NoArgsCommand):
+class Command(CronArgMixin, NoArgsCommand):
     help = "Do one pass through the mail queue, attempting to send all mail."
 
     def handle_noargs(self, **options):

--- a/mailer/management/commands/send_mail.py
+++ b/mailer/management/commands/send_mail.py
@@ -1,5 +1,4 @@
 import logging
-from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import NoArgsCommand

--- a/mailer/management/commands/send_mail.py
+++ b/mailer/management/commands/send_mail.py
@@ -11,13 +11,31 @@ from mailer.engine import send_all
 # allow a sysadmin to pause the sending of mail temporarily.
 PAUSE_SEND = getattr(settings, "MAILER_PAUSE_SEND", False)
 
+help_msg = "If 1 don't print messagges, but only errors."
 
-class Command(NoArgsCommand):
+
+if NoArgsCommand.option_list:
+    # old; optparse
+    class ArgsMixin(object):
+        base_options = (
+            make_option('-c', '--cron', default=0, type='int', help=help_msg),
+        )
+        option_list = NoArgsCommand.option_list + base_options
+else:
+    # new; argparse
+    class ArgsMixin(object):
+        def add_arguments(self, parser):
+            parser.add_argument(
+                '-c',
+                '--cron',
+                default=0,
+                type=int,
+                help=help_msg,
+            )
+
+
+class Command(ArgsMixin, NoArgsCommand):
     help = "Do one pass through the mail queue, attempting to send all mail."
-    base_options = (
-        make_option('-c', '--cron', default=0, type='int', help='If 1 don\'t print messagges, but only errors.'),  # noqa
-    )
-    option_list = NoArgsCommand.option_list + base_options
 
     def handle_noargs(self, **options):
         if options['cron'] == 0:

--- a/mailer/management/helpers.py
+++ b/mailer/management/helpers.py
@@ -1,3 +1,5 @@
+from optparse import make_option
+
 from django.core.management.base import NoArgsCommand
 
 help_msg = "If 1 don't print messagges, but only errors."
@@ -21,5 +23,3 @@ else:
                 type=int,
                 help=help_msg,
             )
-
-

--- a/mailer/management/helpers.py
+++ b/mailer/management/helpers.py
@@ -1,0 +1,25 @@
+from django.core.management.base import NoArgsCommand
+
+help_msg = "If 1 don't print messagges, but only errors."
+
+
+if NoArgsCommand.option_list:
+    # pre django 1.8; use optparse
+    class CronArgMixin(object):
+        base_options = (
+            make_option('-c', '--cron', default=0, type='int', help=help_msg),
+        )
+        option_list = NoArgsCommand.option_list + base_options
+else:
+    # django 1.8+; use argparse
+    class CronArgMixin(object):
+        def add_arguments(self, parser):
+            parser.add_argument(
+                '-c',
+                '--cron',
+                default=0,
+                type=int,
+                help=help_msg,
+            )
+
+

--- a/mailer/tests.py
+++ b/mailer/tests.py
@@ -614,4 +614,3 @@ class TestCommandHelper(TestCase):
         with patch('mailer.management.commands.retry_deferred.logging') as logging:
             call_command('retry_deferred', '--cron', '1')
             logging.basicConfig.assert_called_with(level=logging.ERROR, format=ANY)
-

--- a/mailer/tests.py
+++ b/mailer/tests.py
@@ -10,7 +10,7 @@ from mailer.models import (Message, MessageLog, DontSendEntry, db_to_email, emai
 import mailer
 from mailer import engine
 
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 import pickle
 import lockfile
 import smtplib
@@ -582,3 +582,36 @@ class TestDbToEmail(TestCase):
         self.assertEqual(converted_email.subject, email.subject)
         self.assertEqual(converted_email.from_email, email.from_email)
         self.assertEqual(converted_email.to, email.to)
+
+
+class TestCommandHelper(TestCase):
+    def test_send_mail_no_cron(self):
+        with patch('mailer.management.commands.send_mail.logging') as logging:
+            call_command('send_mail')
+            logging.basicConfig.assert_called_with(level=logging.DEBUG, format=ANY)
+
+    def test_send_mail_cron_0(self):
+        with patch('mailer.management.commands.send_mail.logging') as logging:
+            call_command('send_mail', '--cron', '0')
+            logging.basicConfig.assert_called_with(level=logging.DEBUG, format=ANY)
+
+    def test_send_mail_cron_1(self):
+        with patch('mailer.management.commands.send_mail.logging') as logging:
+            call_command('send_mail', '--cron', '1')
+            logging.basicConfig.assert_called_with(level=logging.ERROR, format=ANY)
+
+    def test_retry_deferred_no_cron(self):
+        with patch('mailer.management.commands.retry_deferred.logging') as logging:
+            call_command('retry_deferred')
+            logging.basicConfig.assert_called_with(level=logging.DEBUG, format=ANY)
+
+    def test_retry_deferred_cron_0(self):
+        with patch('mailer.management.commands.retry_deferred.logging') as logging:
+            call_command('retry_deferred', '--cron', '0')
+            logging.basicConfig.assert_called_with(level=logging.DEBUG, format=ANY)
+
+    def test_retry_deferred_cron_1(self):
+        with patch('mailer.management.commands.retry_deferred.logging') as logging:
+            call_command('retry_deferred', '--cron', '1')
+            logging.basicConfig.assert_called_with(level=logging.ERROR, format=ANY)
+

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,11 @@ deps =
     lockfile==0.10.2
     coverage
     mock==1.0.1
-    django14: Django==1.4.20
+    django14: Django==1.4.22
     django15: Django==1.5.12
     django16: Django==1.6.11
-    django17: Django==1.7.8
-    django18: Django==1.8.2
+    django17: Django==1.7.11
+    django18: Django==1.8.13
     django19: Django==1.9.6
     flake: flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 # Remember to add to .travis.yml if this is added to.
 envlist =
     py27-django{14,15,16,17,18,19}-test,
-    {py33,py34}-django{15,16,17,18,19}-test,
+    py33-django{15,16,17,18}-test,
+    py34-django{15,16,17,18,19}-test,
     {py27,py33,py34}-flake,
     checkmanifest,
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 # Remember to add to .travis.yml if this is added to.
-envlist = py27-django{14,15,16,17,18,19}-test, {py33,py34}-django{15,16,17,18,19}-test, {py27,py33,py34}-flake, checkmanifest
+envlist =
+    py27-django{14,15,16,17,18,19}-test,
+    {py33,py34}-django{15,16,17,18,19}-test,
+    {py27,py33,py34}-flake,
+    checkmanifest,
 
 [flake8]
 max-line-length=100
@@ -16,16 +20,16 @@ commands =
     test: coverage run ./runtests.py
     flake: flake8 --statistics --benchmark mailer
 deps =
-     lockfile==0.10.2
-     coverage
-     mock==1.0.1
-     django14: Django==1.4.20
-     django15: Django==1.5.12
-     django16: Django==1.6.11
-     django17: Django==1.7.8
-     django18: Django==1.8.2
-     django19: Django==1.9.6
-     flake: flake8
+    lockfile==0.10.2
+    coverage
+    mock==1.0.1
+    django14: Django==1.4.20
+    django15: Django==1.5.12
+    django16: Django==1.6.11
+    django17: Django==1.7.8
+    django18: Django==1.8.2
+    django19: Django==1.9.6
+    flake: flake8
 
 [testenv:checkmanifest]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Remember to add to .travis.yml if this is added to.
-envlist = py27-django{14,15,16,17,18}-test, {py33,py34}-django{15,16,17,18}-test, {py27,py33,py34}-flake, checkmanifest
+envlist = py27-django{14,15,16,17,18,19}-test, {py33,py34}-django{15,16,17,18,19}-test, {py27,py33,py34}-flake, checkmanifest
 
 [flake8]
 max-line-length=100
@@ -24,6 +24,7 @@ deps =
      django16: Django==1.6.11
      django17: Django==1.7.8
      django18: Django==1.8.2
+     django19: Django==1.9.6
      flake: flake8
 
 [testenv:checkmanifest]


### PR DESCRIPTION
use argparse for django 1.8+ to avoid deprecation warnings