### PR TITLE
Fixed #64 Django110Warning: NoArgsCommand class is deprecated

### DIFF
--- a/mailer/management/commands/retry_deferred.py
+++ b/mailer/management/commands/retry_deferred.py
@@ -1,16 +1,16 @@
 import logging
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import connection
 
 from mailer.models import Message
 from mailer.management.helpers import CronArgMixin
 
 
-class Command(CronArgMixin, NoArgsCommand):
+class Command(CronArgMixin, BaseCommand):
     help = "Attempt to resend any deferred mail."
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         if options['cron'] == 0:
             logging.basicConfig(level=logging.DEBUG, format="%(message)s")
         else:

--- a/mailer/management/commands/send_mail.py
+++ b/mailer/management/commands/send_mail.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import connection
 
 from mailer.engine import send_all
@@ -12,10 +12,10 @@ from mailer.management.helpers import CronArgMixin
 PAUSE_SEND = getattr(settings, "MAILER_PAUSE_SEND", False)
 
 
-class Command(CronArgMixin, NoArgsCommand):
+class Command(CronArgMixin, BaseCommand):
     help = "Do one pass through the mail queue, attempting to send all mail."
 
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         if options['cron'] == 0:
             logging.basicConfig(level=logging.DEBUG, format="%(message)s")
         else:


### PR DESCRIPTION
Fixed Django110Warning: NoArgsCommand class is deprecated and will be removed in Django 1.10. Use BaseCommand instead, which takes no arguments by default.