### PR TITLE
Don't defer messages with non-retryable errors.

### DIFF
--- a/mailer/models.py
+++ b/mailer/models.py
@@ -236,11 +236,13 @@ class DontSendEntry(models.Model):
 RESULT_SUCCESS = "1"
 RESULT_DONT_SEND = "2"
 RESULT_FAILURE = "3"
+RESULT_ERROR = "4"
 
 RESULT_CODES = (
     (RESULT_SUCCESS, "success"),
     (RESULT_DONT_SEND, "don't send"),
-    (RESULT_FAILURE, "failure"),
+    (RESULT_FAILURE, "failure (retryable)"),
+    (RESULT_ERROR, "error (non-retryable)"),
     # @@@ other types of failure?
 )
 


### PR DESCRIPTION
If sending a message raises a "non-retryable" error,
delete the Message from the queue, and note the error
in the MessageLog with a new `RESULT_ERROR` status.
(Retryable errors continue to be deferred and logged with
`RESULT_FAILURE`.)

This addresses two, related problems:
1. Deferring a message with an expected, but non-retryable
   error would over time grow the deferred queue (repeatedly
   hammering the backend with the same unsendable messages).
2. Sending a message with an unhandled error would
   interrupt the send_all, immediately and permanently
   stalling the entire queue.

"Non-retryable" errors are:
* Anything where the original message would need to be altered
  to be sent successfully. (E.g., a sender not recognized
  by your SMTP server, or a malformed recipient address.)
  Covers the first problem.
* Catchall `Exception` for anything not explicitly enumerated
  as a transient, retryable error (like a network issue). The catchall
  covers most errors raised by third-party EmailBackends.
  Addresses the second problem.

Addresses #73.