### PR TITLE
Clean up send error handling; fix stalled send queue.

### DIFF
--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -12,8 +12,7 @@ from django.core.mail import get_connection
 from django.core.mail.message import make_msgid
 
 from mailer.models import (
-    Message, MessageLog, RESULT_SUCCESS, RESULT_FAILURE, get_message_id,
-)
+    Message, MessageLog, RESULT_SUCCESS, RESULT_FAILURE, RESULT_ERROR, get_message_id)
 
 
 # when queue is empty, how long to wait (in seconds) before checking again
@@ -103,7 +102,7 @@ def release_lock(lock):
     logging.debug("released.")
 
 
-def send_all():
+def send_all():  # noqa: C901  # TODO: refactor to reduce complexity
     """
     Send all eligible messages in the queue.
     """
@@ -122,6 +121,7 @@ def send_all():
     start_time = time.time()
 
     deferred = 0
+    errored = 0
     sent = 0
 
     try:
@@ -154,10 +154,17 @@ def send_all():
                     logging.warning("message discarded due to failure in converting from DB. Added on '%s' with priority '%s'" % (message.when_added, message.priority))  # noqa
                 message.delete()
 
-            except (socket_error, smtplib.SMTPSenderRefused,
-                    smtplib.SMTPRecipientsRefused,
-                    smtplib.SMTPDataError,
-                    smtplib.SMTPAuthenticationError) as err:
+            except (smtplib.SMTPConnectError,
+                    smtplib.SMTPServerDisconnected) as err:
+                # Connection-related problem -- try again soon:
+                logging.info("message left queued due to transient failure: %s" % err)
+                MessageLog.objects.log(message, RESULT_FAILURE, log_message=str(err))
+                break  # connectivity issue; resume batch next time
+
+            except (socket_error,  # includes smtplib.SMTPException in python3.4+
+                    # TODO: consider handling socket_error/OSError/IOError as "retry soon"???
+                    smtplib.SMTPException) as err:
+                # Destination/recipient-related problem -- try again later:
                 message.defer()
                 logging.info("message deferred due to failure: %s" % err)
                 MessageLog.objects.log(message, RESULT_FAILURE, log_message=str(err))
@@ -165,8 +172,17 @@ def send_all():
                 # Get new connection, it case the connection itself has an error.
                 connection = None
 
+            except Exception as err:
+                # Content-specific (or unknown) problem -- don't retry this message:
+                logging.info("message discarded due to error: %s" % err)
+                MessageLog.objects.log(message, RESULT_ERROR, log_message=str(err))
+                message.delete()
+                errored += 1
+                # Get new connection, it case the connection itself has an error.
+                connection = None
+
             # Check if we reached the limits for the current run
-            if _limits_reached(sent, deferred):
+            if _limits_reached(sent, deferred):  # TODO: add limits for errored???
                 break
 
             _throttle_emails()
@@ -175,7 +191,7 @@ def send_all():
         release_lock(lock)
 
     logging.info("")
-    logging.info("%s sent; %s deferred;" % (sent, deferred))
+    logging.info("%s sent; %s deferred; %s errored" % (sent, deferred, errored))
     logging.info("done in %.2f seconds" % (time.time() - start_time))
 
 

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -236,11 +236,13 @@ class DontSendEntry(models.Model):
 RESULT_SUCCESS = "1"
 RESULT_DONT_SEND = "2"
 RESULT_FAILURE = "3"
+RESULT_ERROR = "4"
 
 RESULT_CODES = (
     (RESULT_SUCCESS, "success"),
     (RESULT_DONT_SEND, "don't send"),
-    (RESULT_FAILURE, "failure"),
+    (RESULT_FAILURE, "failure (retryable)"),
+    (RESULT_ERROR, "error (non-retryable)"),
     # @@@ other types of failure?
 )
 


### PR DESCRIPTION
[NOT FOR MERGE yet: see "TODO" comments for discussion]

In engine.send_all:

* Handle transient connection issues by logging failure
  and cleanly exiting send_all. (Previously, crashed
  without logging.)
* Handle all other smtplib.SMTPException by deferring
  message. (Previously, behavior differed between
  Python 2 and 3.)
* Handle all other exceptions by logging error with new
  RESULT_ERROR status, and deleting message from send 
  queue. (Previously, crashed without logging, leaving 
  possibly-unsendable message blocking send queue.)

**Potentially-breaking change:** If you are using a
MAILER_EMAIL_BACKEND other than the default
SMTP EmailBackend, errors from that backend *may*
be handled differently now.

Addresses #73. (And additional discussion there.)