### PR TITLE
Fix encoding error

### DIFF
--- a/mailer/models.py
+++ b/mailer/models.py
@@ -4,6 +4,7 @@ import base64
 import logging
 import pickle
 import datetime
+import sys
 
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now as datetime_now
@@ -90,7 +91,7 @@ def db_to_email(data):
         return None
     else:
         try:
-            data = data.encode("ascii")
+            data = data.encode(sys.getdefaultencoding())
         except AttributeError:
             pass
 


### PR DESCRIPTION
When I run the ** python manage.py send_mail ** python show the exception below, because the email has latin characters:

```
Traceback (most recent call last):
  File "/var/www/anppom/manage.py", line 24, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/django/core/management/base.py", line 294, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/django/core/management/base.py", line 345, in execute
    output = self.handle(*args, **options)
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/mailer/management/commands/send_mail.py", line 26, in handle
    send_all()
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/mailer/engine.py", line 132, in send_all
    message.subject.encode("utf-8"),
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/mailer/models.py", line 164, in subject
    email = self.email
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/mailer/models.py", line 143, in _get_email
    return db_to_email(self.message_data)
  File "/opt/virtualenvs/anppom/lib/python3.4/site-packages/mailer/models.py", line 92, in db_to_email
    data = data.encode("ascii")
UnicodeEncodeError: 'ascii' codec can't encode character '\xe1' in position 62: ordinal not in range(128)
```
