### PR TITLE
Catch all exceptions and defer the message

### DIFF
--- a/mailer/engine.py
+++ b/mailer/engine.py
@@ -163,10 +163,7 @@ def send_all():
                     logging.warning("message discarded due to failure in converting from DB. Added on '%s' with priority '%s'" % (message.when_added, message.priority))  # noqa
                 message.delete()
 
-            except (socket_error, smtplib.SMTPSenderRefused,
-                    smtplib.SMTPRecipientsRefused,
-                    smtplib.SMTPDataError,
-                    smtplib.SMTPAuthenticationError) as err:
+            except Exception as err:
                 message.defer()
                 logging.info("message deferred due to failure: %s" % err)
                 MessageLog.objects.log(message, RESULT_FAILURE, log_message=str(err))


### PR DESCRIPTION
Surely the easiest stop gap for non-standard email backend exceptions.  Not ideal in that it would be nice to trigger more appropriate responses to the errors being thrown but being that the current behaviour breaks mail queues and there is no PR in site for a more complex and flexible solution this PR strikes a balance and allows the site op to determine what to do with undeliverable mail.

The current leading PR deletes undeliverable mail sent by non-smtplib backends which is destructive and hard to recover if the error was only transient.  This allows further investigation or simply delete-all-deferred type task which is trivial to create and run.