### PR TITLE
django 2.0 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ env:
   - TOXENV=py27-django19-test
   - TOXENV=py27-django110-test
   - TOXENV=py27-django111-test
-  - TOXENV=py33-django15-test
-  - TOXENV=py33-django16-test
-  - TOXENV=py33-django17-test
-  - TOXENV=py33-django18-test
   - TOXENV=py34-django15-test
   - TOXENV=py34-django16-test
   - TOXENV=py34-django17-test
@@ -32,7 +28,6 @@ env:
   - TOXENV=py36-django111-test
   - TOXENV=py36-django20-test
   - TOXENV=py27-flake
-  - TOXENV=py33-flake
   - TOXENV=py34-flake
   - TOXENV=py35-flake
   - TOXENV=py36-flake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-python: 3.6  # this is needed to fool travis to have python3.6 as well
 env:
   - TOXENV=py27-django14-test
   - TOXENV=py27-django15-test
@@ -17,21 +16,38 @@ env:
   - TOXENV=py34-django110-test
   - TOXENV=py34-django111-test
   - TOXENV=py34-django20-test
-  - TOXENV=py35-django18-test
-  - TOXENV=py35-django19-test
-  - TOXENV=py35-django110-test
-  - TOXENV=py35-django111-test
-  - TOXENV=py35-django20-test
-  - TOXENV=py36-django18-test
-  - TOXENV=py36-django19-test
-  - TOXENV=py36-django110-test
-  - TOXENV=py36-django111-test
-  - TOXENV=py36-django20-test
   - TOXENV=py27-flake
   - TOXENV=py34-flake
-  - TOXENV=py35-flake
-  - TOXENV=py36-flake
   - TOXENV=checkmanifest
+
+ # this is needed for python 3.5 and 3.6
+matrix:
+  include:
+  - python: 3.5
+    env: TOXENV=py35-django18-test
+  - python: 3.5
+    env: TOXENV=py35-django19-test
+  - python: 3.5
+    env: TOXENV=py35-django110-test
+  - python: 3.5
+    env: TOXENV=py35-django111-test
+  - python: 3.5
+    env: TOXENV=py35-django20-test
+  - python: 3.5
+    env: TOXENV=py35-flake
+  - python: 3.6
+    env: TOXENV=py36-django18-test
+  - python: 3.6
+    env: TOXENV=py36-django19-test
+  - python: 3.6
+    env: TOXENV=py36-django110-test
+  - python: 3.6
+    env: TOXENV=py36-django111-test
+  - python: 3.6
+    env: TOXENV=py36-django20-test
+  - python: 3.6
+    env: TOXENV=py36-flake
+
 install:
   - pip install coveralls tox>=2.1
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5  # this is needed to fool travis to have python3.5 as well
+python: 3.6  # this is needed to fool travis to have python3.6 as well
 env:
   - TOXENV=py27-django14-test
   - TOXENV=py27-django15-test
@@ -9,18 +9,33 @@ env:
   - TOXENV=py27-django19-test
   - TOXENV=py27-django110-test
   - TOXENV=py27-django111-test
+  - TOXENV=py33-django15-test
+  - TOXENV=py33-django16-test
+  - TOXENV=py33-django17-test
+  - TOXENV=py33-django18-test
+  - TOXENV=py34-django15-test
   - TOXENV=py34-django16-test
   - TOXENV=py34-django17-test
   - TOXENV=py34-django18-test
   - TOXENV=py34-django19-test
   - TOXENV=py34-django110-test
   - TOXENV=py34-django111-test
+  - TOXENV=py34-django20-test
   - TOXENV=py35-django18-test
   - TOXENV=py35-django19-test
   - TOXENV=py35-django110-test
   - TOXENV=py35-django111-test
+  - TOXENV=py35-django20-test
+  - TOXENV=py36-django18-test
+  - TOXENV=py36-django19-test
+  - TOXENV=py36-django110-test
+  - TOXENV=py36-django111-test
+  - TOXENV=py36-django20-test
   - TOXENV=py27-flake
+  - TOXENV=py33-flake
   - TOXENV=py34-flake
+  - TOXENV=py35-flake
+  - TOXENV=py36-flake
   - TOXENV=checkmanifest
 install:
   - pip install coveralls tox>=2.1

--- a/mailer/models.py
+++ b/mailer/models.py
@@ -80,9 +80,11 @@ base64_decode = base64.decodebytes if hasattr(base64, 'decodebytes') else base64
 
 
 def email_to_db(email):
-    # pickle.dumps returns essentially binary data which we need to encode
-    # to store in a unicode field.
-    return base64_encode(pickle.dumps(email))
+    # pickle.dumps returns essentially binary data which we need to base64
+    # encode to store in a unicode field. finally we encode back to make sure
+    # we only try to insert unicode strings into the db, since we use a
+    # TextField
+    return base64_encode(pickle.dumps(email)).decode('ascii')
 
 
 def db_to_email(data):

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@
 envlist =
     py27-django{14,15,16,17,18,19,110,111}-test,
     py33-django{15,16,17,18}-test,
-    py34-django{15,16,17,18,19,110,111}-test,
-    py35-django{18,19,110,111}-test,
-    {py27,py33,py34,py35}-flake,
+    py34-django{15,16,17,18,19,110,111,20}-test,
+    {py35,py36}-django{18,19,110,111,20}-test,
+    {py27,py33,py34,py35,py36}-flake,
     checkmanifest,
 
 [flake8]
@@ -19,6 +19,7 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 commands =
     test: coverage run ./runtests.py
     flake: flake8 --statistics --benchmark mailer
@@ -30,10 +31,11 @@ deps =
     django15: Django==1.5.12
     django16: Django==1.6.11
     django17: Django==1.7.11
-    django18: Django==1.8.17
-    django19: Django==1.9.12
-    django110: Django==1.10.5
-    django111: Django==1.11.4
+    django18: Django==1.8.18
+    django19: Django==1.9.13
+    django110: Django==1.10.8
+    django111: Django==1.11.8
+    django20: Django==2.0
     flake: flake8==3.2.1
     py27-flake: Django<2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,9 @@
 # Remember to add to .travis.yml if this is added to.
 envlist =
     py27-django{14,15,16,17,18,19,110,111}-test,
-    py33-django{15,16,17,18}-test,
     py34-django{15,16,17,18,19,110,111,20}-test,
     {py35,py36}-django{18,19,110,111,20}-test,
-    {py27,py33,py34,py35,py36}-flake,
+    {py27,py34,py35,py36}-flake,
     checkmanifest,
 
 [flake8]
@@ -16,7 +15,6 @@ exclude=mailer/south_migrations,mailer/migrations,build
 [testenv]
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
django < 2.0 is fine inserting bytestrings into a textfield, but as of 2.0 there is a (py3) `isinstance(str)` -> `str(value)` which for `b'foo'` becomes `"b'foo'"`