### PR TITLE
Changed send_messages to use bulk_create for optimization

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -130,3 +130,8 @@ absolute path to the file to be used as a lock. The extension ".lock" will be
 added. The process running ``send_mail`` needs to have permissions to create and
 delete this file, and others in the same directory. With the default value of
 ``None`` django-mailer will use a path in current working directory.
+
+If you need to change the batch size used by django-mailer to save messages in
+``mailer.backend.DbBackend``, you can set ``MAILER_MESSAGES_BATCH_SIZE`` to a 
+value more suitable for you. By default, no value defined, inheriting django
+default behavior when passing batch size as ``None``. 

--- a/mailer/backend.py
+++ b/mailer/backend.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+
+from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 
 from mailer.models import Message
@@ -6,10 +9,11 @@ from mailer.models import Message
 class DbBackend(BaseEmailBackend):
 
     def send_messages(self, email_messages):
-        num_sent = 0
-        for email in email_messages:
-            msg = Message()
-            msg.email = email
-            msg.save()
-            num_sent += 1
-        return num_sent
+        # allow for a custom batch size
+        MESSAGES_BATCH_SIZE = getattr(settings, "MAILER_MESSAGES_BATCH_SIZE", None)
+
+        messages = Message.objects.bulk_create([
+            Message(email=email) for email in email_messages
+        ], MESSAGES_BATCH_SIZE)
+
+        return len(messages)

--- a/mailer/tests.py
+++ b/mailer/tests.py
@@ -63,6 +63,18 @@ class TestBackend(TestCase):
             mail.send_mail("Subject ☺", "Body", "sender@example.com", ["recipient@example.com"])
             self.assertEqual(Message.objects.count(), 1)
 
+    def test_save_mass_mail_to_db(self):
+        """
+        Test that using send_mass_mail creates multiple Message objects in DB instead, when
+        EMAIL_BACKEND is set.
+        """
+        self.assertEqual(Message.objects.count(), 0)
+        with self.settings(EMAIL_BACKEND="mailer.backend.DbBackend"):
+            message1 = ('Subject ☺', 'Body', 'sender@example.com', ['first@example.com'])
+            message2 = ('Another Subject ☺', 'Body', 'sender@example.com', ['second@test.com'])
+            mail.send_mass_mail((message1, message2))
+            self.assertEqual(Message.objects.count(), 2)
+
 
 class TestSending(TestCase):
     def setUp(self):


### PR DESCRIPTION
Pull request to improve performance when saving messages to database, just like reported in #103.
I added a new setting to allow defining custom `batch_size` to `bulk_create`. I also updated tests with a `send_mass_mail` too, just to ensure there are no problems sending mass mails.