### PR TITLE
Added django 1.11 compat for nowait exception.

### DIFF
--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import get_connection
 from django.core.mail.message import make_msgid
-from django.db import NotSupportedError, OperationalError, transaction
+from django.db import DatabaseError, NotSupportedError, OperationalError, transaction
 from mailer.models import (RESULT_FAILURE, RESULT_SUCCESS, Message, MessageLog,
                            get_message_id)
 
@@ -56,7 +56,7 @@ def sender_context(message):
         try:
             try:
                 yield Message.objects.filter(id=message.id).select_for_update(nowait=True).get()
-            except NotSupportedError:
+            except (DatabaseError, NotSupportedError):
                 # MySQL
                 yield Message.objects.filter(id=message.id).select_for_update().get()
         except Message.DoesNotExist:


### PR DESCRIPTION
Hi,

I'm using django-mailer with In Django 1.11 and i noticed that the exception caught is only valid for Django 2.0 and up, for 1.11 the exception raised is `DatabaseError` and not `NotSupportedError`.
Documentation: https://docs.djangoproject.com/en/1.11/ref/databases/#row-locking-with-queryset-select-for-update.

This merge fix the problem. 