### PR TITLE
Clarified database limitations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ django-mailer
 ``django-mailer`` is a reusable Django app for queuing the sending of email. 
 It works by storing email in the database for later sending.
 
+Keep in mind that file attachments are also temporarily stored in the database, which means if you are sending files larger than several hundred KB in size, you are likely to run into database limitations on how large your query can be. If this happens, you'll either need to fall back to using Django's default mail backend, or increase your database limits (a procedure that depends on which database you are using).
+
 Requirements
 ------------
 


### PR DESCRIPTION
I don't mean to be rude, but

> It works by storing email in the database for later sending.

does absolutely nothing to clarify why some people may run into problems when sending files. It doesn't even make it obvious that file attachments are also stored in the database, or that databases have limits on how big a query they will accept, which by default will be problematic for files any larger than a few KB, which, these days, is probably most files.

Not everyone working on Django knows every little detail about how the database they are using works, or what limits it may or may not have. I know I don't, until I run into issues like this.
