### PR TITLE
add option to purge mail logs in failed state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Django Mailer
 django-mailer
 -------------
 
-``django-mailer`` is a reusable Django app for queuing the sending of email. 
+``django-mailer`` is a reusable Django app for queuing the sending of email.
 It works by storing email in the database for later sending.
 
 Keep in mind that file attachments are also temporarily stored in the database, which means if you are sending files larger than several hundred KB in size, you are likely to run into database limitations on how large your query can be. If this happens, you'll either need to fall back to using Django's default mail backend, or increase your database limits (a procedure that depends on which database you are using).
@@ -75,6 +75,8 @@ To remove successful log entries older than a week, add this to a cron job file 
 
     0 0 * * * (/path/to/your/python /path/to/your/manage.py purge_mail_log 7 >> ~/cron_mail_purge.log 2>&1)
 
+Use the `-r failure` option to remove only failed log entries instead, or `-r all` to remove them all.
+
 Documentation and support
 -------------------------
 
@@ -83,8 +85,8 @@ in the docs for more advanced use cases.
 The Pinax documentation is available at http://pinaxproject.com/pinax/.
 
 This is an Open Source project maintained by volunteers, and outside this documentation the maintainers
-do not offer other support. For cases where you have found a bug you can file a GitHub issue. 
-In case of any questions we recommend you join the `Pinax Slack team <http://slack.pinaxproject.com>`_ 
+do not offer other support. For cases where you have found a bug you can file a GitHub issue.
+In case of any questions we recommend you join the `Pinax Slack team <http://slack.pinaxproject.com>`_
 and ping the Pinax team there instead of creating an issue on GitHub. You may also be able to get help on
 other programming sites like `Stack Overflow <https://stackoverflow.com/>`_.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -74,7 +74,8 @@ you can run:
 * ``retry_deferred`` will move any deferred mail back into the normal queue
   (so it will be attempted again on the next ``send_mail``).
 
-* ``purge_mail_log`` will remove old successful message logs from the database, to prevent it from filling up your database
+* ``purge_mail_log`` will remove old successful message logs from the database, to prevent it from filling up your database.
+  Use the ``-r failure`` option to remove only failed message logs instead, or ``-r all`` to remove them all.
 
 
 You may want to set these up via cron to run regularly::

--- a/src/mailer/models.py
+++ b/src/mailer/models.py
@@ -251,9 +251,12 @@ class MessageLogManager(models.Manager):
             log_message=log_message,
         )
 
-    def purge_old_entries(self, days):
+    def purge_old_entries(self, days, result_codes=None):
+        if not result_codes:
+            # retro-compatibility with previous versions
+            result_codes = [RESULT_SUCCESS]
         limit = datetime_now() - datetime.timedelta(days=days)
-        query = self.filter(when_attempted__lt=limit, result=RESULT_SUCCESS)
+        query = self.filter(when_attempted__lt=limit, result__in=result_codes)
         count = query.count()
         query.delete()
         return count

--- a/src/mailer/models.py
+++ b/src/mailer/models.py
@@ -252,7 +252,7 @@ class MessageLogManager(models.Manager):
         )
 
     def purge_old_entries(self, days, result_codes=None):
-        if not result_codes:
+        if result_codes is None:
             # retro-compatibility with previous versions
             result_codes = [RESULT_SUCCESS]
         limit = datetime_now() - datetime.timedelta(days=days)

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -112,6 +112,12 @@ class SendingTest(TestCase):
         self.assertNotEqual(MessageLog.objects.filter(result=RESULT_FAILURE).count(), 0)
         self.assertEqual(MessageLog.objects.filter(result=RESULT_SUCCESS).count(), 0)
 
+        with patch.object(mailer.models, 'datetime_now') as datetime_now_patch:
+            datetime_now_patch.return_value = datetime_now() + datetime.timedelta(days=2)
+            call_command('purge_mail_log', '1', '-r', 'failure')
+
+        self.assertEqual(MessageLog.objects.filter(result=RESULT_FAILURE).count(), 0)
+
     def test_send_loop(self):
         with self.settings(MAILER_EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
             with patch("mailer.engine.send_all", side_effect=StopIteration) as send:

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -120,7 +120,7 @@ class SendingTest(TestCase):
             call_command('purge_mail_log', '1', '-r', 'failure')
 
         self.assertEqual(MessageLog.objects.filter(result=RESULT_FAILURE).count(), 0)
-        self.assertNotEqual(MessageLog.objects.filter(result=RESULT_SUCCESS).count(), 0, MessageLog.objects.count())
+        self.assertNotEqual(MessageLog.objects.filter(result=RESULT_SUCCESS).count(), 0)
 
         # 1 success, 1 failure, and purge everything
         send_mail(False)

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -90,20 +90,20 @@ class SendingTest(TestCase):
             self.assertEqual(Message.objects.count(), 0)
 
     def test_purge_old_entries(self):
-        # Send one successfully
-        with self.settings(MAILER_EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):
-            mailer.send_mail("Subject", "Body", "sender1@example.com",
-                             ["recipient@example.com"])
-            engine.send_all()
 
-        # And one failure
-        with self.settings(MAILER_EMAIL_BACKEND="tests.FailingMailerEmailBackend"):
-            mailer.send_mail("Subject", "Body", "sender2@example.com",
-                             ["recipient@example.com"])
+        def send_mail(success):
+            backend = ("django.core.mail.backends.locmem.EmailBackend"
+                       if success else "tests.FailingMailerEmailBackend")
+            with self.settings(MAILER_EMAIL_BACKEND=backend):
+                mailer.send_mail("Subject", "Body", "sender@example.com", ["recipient@example.com"])
+                engine.send_all()
+                if not success:
+                    Message.objects.retry_deferred()
+                    engine.send_all()
 
-            engine.send_all()
-            Message.objects.retry_deferred()
-            engine.send_all()
+        # 1 success, 1 failure, and purge only success
+        send_mail(True)
+        send_mail(False)
 
         with patch.object(mailer.models, 'datetime_now') as datetime_now_patch:
             datetime_now_patch.return_value = datetime_now() + datetime.timedelta(days=2)
@@ -112,11 +112,24 @@ class SendingTest(TestCase):
         self.assertNotEqual(MessageLog.objects.filter(result=RESULT_FAILURE).count(), 0)
         self.assertEqual(MessageLog.objects.filter(result=RESULT_SUCCESS).count(), 0)
 
+        # 1 success, 1 failure, and purge only failures
+        send_mail(True)
+
         with patch.object(mailer.models, 'datetime_now') as datetime_now_patch:
             datetime_now_patch.return_value = datetime_now() + datetime.timedelta(days=2)
             call_command('purge_mail_log', '1', '-r', 'failure')
 
         self.assertEqual(MessageLog.objects.filter(result=RESULT_FAILURE).count(), 0)
+        self.assertNotEqual(MessageLog.objects.filter(result=RESULT_SUCCESS).count(), 0, MessageLog.objects.count())
+
+        # 1 success, 1 failure, and purge everything
+        send_mail(False)
+
+        with patch.object(mailer.models, 'datetime_now') as datetime_now_patch:
+            datetime_now_patch.return_value = datetime_now() + datetime.timedelta(days=2)
+            call_command('purge_mail_log', '1', '-r', 'all')
+
+        self.assertEqual(MessageLog.objects.count(), 0)
 
     def test_send_loop(self):
         with self.settings(MAILER_EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"):


### PR DESCRIPTION
Closes #124.

Changes proposed in this PR:

* added a `-r`/`--result` option to the `purge_mail_log` command in order to remove message logs based on their result code:
  * `-r success` (default behaviour for retro-compatibility) to filter logs with `RESULT_SUCCESS` code
  * `-r failure` to filter logs with `RESULT_FAILURE` code
  * `-r all` to filter logs with either `RESULT_SUCCESS` or `RESULT_FAILURE` codes
* updated the documentation accordingly

I didn't updated the project's version, as I'm not sure you want to publish a new release just for this simple feature.

