### PR TITLE
use mock from the standard library rather than an external package

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ To set up your environment to be able to work on django-mailer, do the following
 
 4. Install test requirements::
 
-    $ pip install coverage mock
+    $ pip install coverage
 
 5. Create a branch for local development::
 
@@ -51,7 +51,7 @@ When writing code to be included in django-mailer keep our style in mind:
 
 * Follow `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ . There are some
   cases where we do not follow PEP8 but it is an excellent starting point.
-* Follow `Django's coding style <http://docs.djangoproject.com/en/dev/internals/contributing/#coding-style>`_ 
+* Follow `Django's coding style <http://docs.djangoproject.com/en/dev/internals/contributing/#coding-style>`_
   we're pretty much in agreement on Django style outlined there.
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,13 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Framework :: Django",
     ],
     install_requires=[
         'Django >= 1.11',
         'lockfile >= 0.8',
         'six',
-        ],
+    ]
 )

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -5,6 +5,11 @@ import datetime
 import pickle
 import time
 
+try:
+    from unittest.mock import ANY, Mock, patch
+except ImportError:
+    from mock import ANY, Mock, patch
+
 import django
 import lockfile
 from django.core import mail
@@ -12,7 +17,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.timezone import now as datetime_now
-from mock import ANY, Mock, patch
 import six
 
 import mailer

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,7 @@ deps =
     six
     lockfile==0.10.2
     coverage
-    py27: mock==3.0.5
-    py34: mock==3.0.5
-    py35: mock==3.0.5
-    py36: mock==4.0.1
-    py37: mock==4.0.1
-    py38: mock==4.0.1
+    py27: mock
     django111: Django==1.11.29
     django20: Django==2.0.13
     django21: Django==2.1.15


### PR DESCRIPTION
Changes proposed in this PR:

* the `mock` package has been included in the standard library since python 3.3. This PR makes sure that we use this built-in package instead of the backport package
* update `setup.py`'s classifiers with the latest supported python versions

Note: I removed the installation of `mock` from the `CONTRIBUTING.md` documentation, as it is now only required for python 2.7. I preferred to omit it to simplify the documentation, considering that from now on most developpers will (or at least should) use python 3 for developping, rather than adding an additional step for python 2 users. But don't hesitate to tell me if you don't agree with this choice!

