### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,50 @@ matrix:
     env: TOXENV=py36-django30-test
   - python: 3.6
     env: TOXENV=py36-flake
+  # Adding ppc64le jobs
+  - python: 2.7
+    arch: ppc64le
+    env: TOXENV=py27-django111-test
+  - python: 2.7
+    arch: ppc64le
+    env: TOXENV=py27-flake
+  - python: 3.4
+    arch: ppc64le
+    env: TOXENV=py34-django111-test
+  - python: 3.4
+    arch: ppc64le
+    env: TOXENV=py34-django20-test
+  - python: 3.4
+    arch: ppc64le
+    env: TOXENV=py34-flake
+  - python: 3.5
+    arch: ppc64le
+    env: TOXENV=py35-django111-test
+  - python: 3.5
+    arch: ppc64le
+    env: TOXENV=py35-django20-test
+  - python: 3.5
+    arch: ppc64le
+    env: TOXENV=py35-flake
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-django111-test
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-django20-test
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-django21-test
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-django22-test
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-django30-test
+  - python: 3.6
+    arch: ppc64le
+    env: TOXENV=py36-flake
+
 
 install:
   - pip install coveralls tox>=2.1
@@ -41,3 +85,5 @@ script:
 after_script:
   - coveralls
 sudo: false
+before_install:
+  - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then  sudo chown -R $USER:$GROUP ~/.cache/pip/wheels; fi


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-mailer/builds/191104152

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj