### PR TITLE
prevent interference with other logging by not using root logger

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ ADDITIONAL CONTRIBUTORS include:
     * Jannis Leidel
     * Luke Plant
     * Renato Alves
+    * Paul Brown

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change log
 2.1 - under development
 -----------------------
 
+* Changed logging to use module specific loggers to avoid interfering
+  with other loggers.
 * Added ``-r`` option to ``purge_mail_log`` management command. Thanks julienc91
 * Fixed deprecation warnings on Django 3.1
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Change log
 2.1 - under development
 -----------------------
 
-* Deprecated the ``-c/--cron`` option in the ``retry_deferred`` management
-  command and removed unnecessary logic to configure log levels and the message
-  format. This command relies on the log level set in your django project now.
+* The ``retry_deferred`` and ``send_mail`` commands rely on the log level set
+  in your django project now. The ``-c/--cron`` option in those commands has
+  been deprecated and the logic to configure log levels and the message
+  format has been removed.
 * Changed logging to use module specific loggers to avoid interfering
   with other loggers.
 * Added ``-r`` option to ``purge_mail_log`` management command. Thanks julienc91

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change log
 2.1 - under development
 -----------------------
 
+* Deprecated the ``-c/--cron`` option in the ``retry_deferred`` management
+  command and removed unnecessary logic to configure log levels and the message
+  format. This command relies on the log level set in your django project now.
 * Changed logging to use module specific loggers to avoid interfering
   with other loggers.
 * Added ``-r`` option to ``purge_mail_log`` management command. Thanks julienc91

--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -132,10 +132,10 @@ def acquire_lock():
     try:
         lock.acquire(LOCK_WAIT_TIMEOUT)
     except lockfile.AlreadyLocked:
-        logger.debug("lock already in place. quitting.")
+        logger.error("lock already in place. quitting.")
         return False, lock
     except lockfile.LockTimeout:
-        logger.debug("waiting for the lock timed out. quitting.")
+        logger.error("waiting for the lock timed out. quitting.")
         return False, lock
     logger.debug("acquired.")
     return True, lock

--- a/src/mailer/management/commands/purge_mail_log.py
+++ b/src/mailer/management/commands/purge_mail_log.py
@@ -8,6 +8,8 @@ RESULT_CODES = {
     'all': [RESULT_SUCCESS, RESULT_FAILURE]
 }
 
+logger = logging.getLogger(__name__)
+
 
 class Command(BaseCommand):
     help = "Delete mailer log"
@@ -23,4 +25,4 @@ class Command(BaseCommand):
         result_codes = RESULT_CODES.get(options['result'])
 
         count = MessageLog.objects.purge_old_entries(days, result_codes)
-        logging.info("%s log entries deleted " % count)
+        logger.info("%s log entries deleted " % count)

--- a/src/mailer/management/commands/retry_deferred.py
+++ b/src/mailer/management/commands/retry_deferred.py
@@ -3,7 +3,9 @@ import logging
 from django.core.management.base import BaseCommand
 
 from mailer.models import Message
-from mailer.management.helpers import CronArgMixin
+from mailer.management.helpers import setup_logger, CronArgMixin
+
+logger = logging.getLogger(__name__)
 
 
 class Command(CronArgMixin, BaseCommand):
@@ -11,8 +13,8 @@ class Command(CronArgMixin, BaseCommand):
 
     def handle(self, *args, **options):
         if options['cron'] == 0:
-            logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+            setup_logger(logger, level=logging.DEBUG)
         else:
-            logging.basicConfig(level=logging.ERROR, format="%(message)s")
+            setup_logger(logger, level=logging.ERROR)
         count = Message.objects.retry_deferred()  # @@@ new_priority not yet supported
-        logging.info("%s message(s) retried" % count)
+        logger.info("%s message(s) retried" % count)

--- a/src/mailer/management/commands/retry_deferred.py
+++ b/src/mailer/management/commands/retry_deferred.py
@@ -1,9 +1,10 @@
 import logging
+import warnings
 
 from django.core.management.base import BaseCommand
 
 from mailer.models import Message
-from mailer.management.helpers import setup_logger, CronArgMixin
+from mailer.management.helpers import CronArgMixin
 
 logger = logging.getLogger(__name__)
 
@@ -12,9 +13,9 @@ class Command(CronArgMixin, BaseCommand):
     help = "Attempt to resend any deferred mail."
 
     def handle(self, *args, **options):
-        if options['cron'] == 0:
-            setup_logger(logger, level=logging.DEBUG)
-        else:
-            setup_logger(logger, level=logging.ERROR)
+        if options['cron']:
+            warnings.warn("retry_deferred's -c/--cron option is no longer "
+                          "necessary and will be removed in a future release",
+                          DeprecationWarning)
         count = Message.objects.retry_deferred()  # @@@ new_priority not yet supported
         logger.info("%s message(s) retried" % count)

--- a/src/mailer/management/commands/send_mail.py
+++ b/src/mailer/management/commands/send_mail.py
@@ -1,10 +1,11 @@
 import logging
+import warnings
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from mailer.engine import send_all
-from mailer.management.helpers import setup_logger, CronArgMixin
+from mailer.management.helpers import CronArgMixin
 
 
 # allow a sysadmin to pause the sending of mail temporarily.
@@ -18,9 +19,9 @@ class Command(CronArgMixin, BaseCommand):
 
     def handle(self, *args, **options):
         if options['cron'] == 0:
-            setup_logger(logger, level=logging.DEBUG)
-        else:
-            setup_logger(logger, level=logging.ERROR)
+            warnings.warn("send_mail's -c/--cron option is no longer "
+                          "necessary and will be removed in a future release",
+                          DeprecationWarning)
         logger.info("-" * 72)
         # if PAUSE_SEND is turned on don't do anything.
         if not PAUSE_SEND:

--- a/src/mailer/management/commands/send_mail.py
+++ b/src/mailer/management/commands/send_mail.py
@@ -4,11 +4,13 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from mailer.engine import send_all
-from mailer.management.helpers import CronArgMixin
+from mailer.management.helpers import setup_logger, CronArgMixin
 
 
 # allow a sysadmin to pause the sending of mail temporarily.
 PAUSE_SEND = getattr(settings, "MAILER_PAUSE_SEND", False)
+
+logger = logging.getLogger(__name__)
 
 
 class Command(CronArgMixin, BaseCommand):
@@ -16,12 +18,12 @@ class Command(CronArgMixin, BaseCommand):
 
     def handle(self, *args, **options):
         if options['cron'] == 0:
-            logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+            setup_logger(logger, level=logging.DEBUG)
         else:
-            logging.basicConfig(level=logging.ERROR, format="%(message)s")
-        logging.info("-" * 72)
+            setup_logger(logger, level=logging.ERROR)
+        logger.info("-" * 72)
         # if PAUSE_SEND is turned on don't do anything.
         if not PAUSE_SEND:
             send_all()
         else:
-            logging.info("sending is paused, quitting.")
+            logger.info("sending is paused, quitting.")

--- a/src/mailer/management/helpers.py
+++ b/src/mailer/management/helpers.py
@@ -1,3 +1,5 @@
+import logging
+
 from optparse import make_option
 from django.core.management.base import BaseCommand
 
@@ -22,3 +24,12 @@ else:
                 type=int,
                 help=help_msg,
             )
+
+
+def setup_logger(logger, level):
+    """Configures a logger to only show the message and sets the log level"""
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter('%(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(level)

--- a/src/mailer/management/helpers.py
+++ b/src/mailer/management/helpers.py
@@ -1,5 +1,3 @@
-import logging
-
 from optparse import make_option
 from django.core.management.base import BaseCommand
 
@@ -24,12 +22,3 @@ else:
                 type=int,
                 help=help_msg,
             )
-
-
-def setup_logger(logger, level):
-    """Configures a logger to only show the message and sets the log level"""
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(level)

--- a/src/mailer/models.py
+++ b/src/mailer/models.py
@@ -35,6 +35,8 @@ PRIORITIES = [
 
 PRIORITY_MAPPING = dict((label, v) for (v, label) in PRIORITIES)
 
+logger = logging.getLogger(__name__)
+
 
 def get_message_id(msg):
     # From django.core.mail.message: Email header names are case-insensitive
@@ -113,6 +115,9 @@ def db_to_email(data):
 
 @python_2_unicode_compatible
 class Message(models.Model):
+    """
+    The email stored for later sending.
+    """
 
     # The actual data - a pickled EmailMessage
     message_data = models.TextField()
@@ -173,7 +178,7 @@ def filter_recipient_list(lst):
     retval = []
     for e in lst:
         if DontSendEntry.objects.has_address(e):
-            logging.info("skipping email to %s as on don't send list " % e.encode("utf-8"))
+            logger.info("skipping email to %s as on don't send list " % e.encode("utf-8"))
         else:
             retval.append(e)
     return retval
@@ -269,6 +274,10 @@ class MessageLogManager(models.Manager):
 
 @python_2_unicode_compatible
 class MessageLog(models.Model):
+    """
+    A log entry which stores the result (and optionally a log message) for an
+    attempt to send a Message.
+    """
 
     # fields from Message
     message_data = models.TextField()

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import datetime
-import logging
 import pickle
 import time
 
@@ -13,7 +12,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils.timezone import now as datetime_now
-from mock import ANY, Mock, patch
+from mock import Mock, patch
 import six
 
 import mailer
@@ -661,24 +660,32 @@ def call_command_with_cron_arg(command, cron_value):
         return call_command(command, cron=cron_value)
 
     # newer django; test parsing by passing argument as string
+    # --cron/c command option is deprecated
     return call_command(command, '--cron={}'.format(cron_value))
 
 
 class CommandHelperTest(TestCase):
     def test_send_mail_no_cron(self):
-        with patch('mailer.management.commands.send_mail.setup_logger') as mock_setup_logger:
-            call_command('send_mail')
-            mock_setup_logger.assert_called_with(ANY, level=logging.DEBUG)
+        call_command('send_mail')
 
     def test_send_mail_cron_0(self):
-        with patch('mailer.management.commands.send_mail.setup_logger') as mock_setup_logger:
-            call_command_with_cron_arg('send_mail', 0)
-            mock_setup_logger.assert_called_with(ANY, level=logging.DEBUG)
+        # deprecated
+        call_command_with_cron_arg('send_mail', 0)
 
     def test_send_mail_cron_1(self):
-        with patch('mailer.management.commands.send_mail.setup_logger') as mock_setup_logger:
-            call_command_with_cron_arg('send_mail', 1)
-            mock_setup_logger.assert_called_with(ANY, level=logging.ERROR)
+        # deprecated
+        call_command_with_cron_arg('send_mail', 1)
+
+    def test_retry_deferred_no_cron(self):
+        call_command('retry_deferred')
+
+    def test_retry_deferred_cron_0(self):
+        # deprecated
+        call_command_with_cron_arg('retry_deferred', 0)
+
+    def test_retry_deferred_cron_1(self):
+        # deprecated
+        call_command_with_cron_arg('retry_deferred', 1)
 
 
 class EmailBackendSettingLoopTest(TestCase):

--- a/tests/test_mailer.py
+++ b/tests/test_mailer.py
@@ -680,21 +680,6 @@ class CommandHelperTest(TestCase):
             call_command_with_cron_arg('send_mail', 1)
             mock_setup_logger.assert_called_with(ANY, level=logging.ERROR)
 
-    def test_retry_deferred_no_cron(self):
-        with patch('mailer.management.commands.retry_deferred.setup_logger') as mock_setup_logger:
-            call_command('retry_deferred')
-            mock_setup_logger.assert_called_with(ANY, level=logging.DEBUG)
-
-    def test_retry_deferred_cron_0(self):
-        with patch('mailer.management.commands.retry_deferred.setup_logger') as mock_setup_logger:
-            call_command_with_cron_arg('retry_deferred', 0)
-            mock_setup_logger.assert_called_with(ANY, level=logging.DEBUG)
-
-    def test_retry_deferred_cron_1(self):
-        with patch('mailer.management.commands.retry_deferred.setup_logger') as mock_setup_logger:
-            call_command_with_cron_arg('retry_deferred', 1)
-            mock_setup_logger.assert_called_with(ANY, level=logging.ERROR)
-
 
 class EmailBackendSettingLoopTest(TestCase):
     def test_loop_detection(self):


### PR DESCRIPTION
Currently django-mailer relies on the root logger for logging, but unfortunately this can interfere with other loggers in an application. This can also unintentionally configure the root logger for users who have django configured with `'disable_existing_loggers': True` and potentially cause duplicate log messages.

This PR switches to using module specific loggers with `logger = logging.getLogger(__name__)` to resolve the issue.

This has some other advantages too, like allowing users to adjust log levels for only the django-mailer module.