### PR TITLE
add MAILER_USE_FILE_LOCK setting to disable file locking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Change log
 2.1 - under development
 -----------------------
 
+* Added ``MAILER_USE_FILE_LOCK`` setting to allow disabling file based locking.
 * Added ``-r`` option to ``purge_mail_log`` management command. Thanks julienc91
 * Fixed deprecation warnings on Django 3.1
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -132,6 +132,9 @@ added. The process running ``send_mail`` needs to have permissions to create and
 delete this file, and others in the same directory. With the default value of
 ``None`` django-mailer will use a path in current working directory.
 
+If you need to disable the file-based locking, you can set the
+``MAILER_USE_FILE_LOCK`` setting to ``False``.
+
 If you need to change the batch size used by django-mailer to save messages in
 ``mailer.backend.DbBackend``, you can set ``MAILER_MESSAGES_BATCH_SIZE`` to a
 value more suitable for you. This value, which defaults to `None`, will be passed to

--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -164,12 +164,15 @@ def send_all():
         "MAILER_EMAIL_BACKEND",
         "django.core.mail.backends.smtp.EmailBackend"
     )
+    # allows disabling file locking. The default is True
+    use_file_lock = getattr(settings, "MAILER_USE_FILE_LOCK", True)
 
     _require_no_backend_loop(mailer_email_backend)
 
-    acquired, lock = acquire_lock()
-    if not acquired:
-        return
+    if use_file_lock:
+        acquired, lock = acquire_lock()
+        if not acquired:
+            return
 
     start_time = time.time()
 
@@ -223,7 +226,8 @@ def send_all():
             _throttle_emails()
 
     finally:
-        release_lock(lock)
+        if use_file_lock:
+            release_lock(lock)
 
     logging.info("")
     logging.info("%s sent; %s deferred;" % (sent, deferred))


### PR DESCRIPTION
Closes #117

I ran into an issue recently where the send_mail command crashed and the lock file had to be deleted manually.

Since the database locking was added, I'm not really sure why the file-based locking still exists.

This PR adds the `MAILER_USE_FILE_LOCK` setting which defaults to `True` to keep the existing functionality, but it allows disabling the file based locking for users who see it as a liability.
