### PR TITLE
Use cached DNS_NAME for performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Change log
 * Added ``MAILER_USE_FILE_LOCK`` setting to allow disabling file based locking.
 * Added ``-r`` option to ``purge_mail_log`` management command. Thanks julienc91
 * Fixed deprecation warnings on Django 3.1
-
+* Use cached DNS_NAME for performance
 
 2.0.1 - 2020-03-01
 ------------------

--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import get_connection
 from django.core.mail.message import make_msgid
+from django.core.mail.utils import DNS_NAME
 from django.db import DatabaseError, NotSupportedError, OperationalError, transaction
 from mailer.models import (RESULT_FAILURE, RESULT_SUCCESS, Message, MessageLog, get_message_id)
 
@@ -84,7 +85,8 @@ def get_messages_for_sending():
 
 def ensure_message_id(msg):
     if get_message_id(msg) is None:
-        msg.extra_headers['Message-ID'] = make_msgid()
+        # Use cached DNS_NAME for performance
+        msg.extra_headers['Message-ID'] = make_msgid(domain=DNS_NAME)
 
 
 def _limits_reached(sent, deferred):


### PR DESCRIPTION
I was looking into why the tests seem slow and found out the tests spend a lot of time calling `socket.getfqdn` from `make_msgid`.

It turns out Django already has a fix for this (since at least 1.11): https://github.com/django/django/blob/stable/1.11.x/django/core/mail/message.py#L327-L328 

This PR applies that same fix Django already uses to cache the calls to `getfqdn`.

Before:
```
10 slowest tests:
35.0928s test_purge_old_entries (tests.test_mailer.SendingTest)
35.0737s test_control_max_retry_amount (tests.test_mailer.SendingTest)
20.0494s test_send_mass_mail (tests.test_mailer.SendingTest)
12.0302s test_throttling_delivery (tests.test_mailer.SendingTest)
10.0393s test_retry_deferred (tests.test_mailer.SendingTest)
10.0254s test_blacklisted_emails (tests.test_mailer.SendingTest)
10.0230s test_control_max_delivery_amount (tests.test_mailer.SendingTest)
5.0385s test_message_log (tests.test_mailer.MessagesTest)
5.0163s test_message_log_str (tests.test_mailer.MessagesTest)
5.0160s test_mailer_email_backend (tests.test_mailer.SendingTest)
```

After:
```
10 slowest tests:
5.0401s test_message_log (tests.test_mailer.MessagesTest)
2.0432s test_throttling_delivery (tests.test_mailer.SendingTest)
0.1216s test_purge_old_entries (tests.test_mailer.SendingTest)
0.0720s test_control_max_retry_amount (tests.test_mailer.SendingTest)
0.0596s test_send_mass_mail (tests.test_mailer.SendingTest)
0.0396s test_control_max_delivery_amount (tests.test_mailer.SendingTest)
0.0370s test_prioritize (tests.test_mailer.PrioritizeTest)
0.0346s test_blacklisted_emails (tests.test_mailer.SendingTest)
0.0308s test_retry_deferred (tests.test_mailer.SendingTest)
0.0281s test_save_changes_to_email (tests.test_mailer.SendingTest)
```
