### PR TITLE
Add runmailer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ ADDITIONAL CONTRIBUTORS include:
     * Renato Alves
     * Paul Brown
     * Sebastian Pipping
+    * Jaap Roes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change log
 2.1.1 - Unreleased
 ------------------
 
+* Add ``runmailer`` management command. This command starts a loop that
+  frequently checks the database for new emails. The wait time between
+  checks can be controlled using the ``MAILER_EMPTY_QUEUE_SLEEP`` setting.
+
 2.1 - 2020-12-05
 ----------------
 

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,12 @@ To remove successful log entries older than a week, add this to a cron job file 
 
 Use the `-r failure` option to remove only failed log entries instead, or `-r all` to remove them all.
 
+Note that the ``send_mail`` cronjob can only run at a maximum frequency of once each minute. If a maximum
+delay of 60 seconds between creating an email and sending it is too much, an alternative is available.
+
+Using ``./manage.py runmailer`` a long running process is started that will check the database
+for new emails each ``MAILER_EMPTY_QUEUE_SLEEP`` (default: 30 seconds).
+
 Documentation and support
 -------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,12 +64,17 @@ or all managers as defined in the ``MANAGERS`` setting by calling::
 Clear queue with command extensions
 ===================================
 
-With mailer in your INSTALLED_APPS, there will be three new manage.py commands
-you can run:
+With mailer in your ``INSTALLED_APPS``, there will be four new
+``manage.py`` commands you can run:
 
 * ``send_mail`` will clear the current message queue. If there are any
   failures, they will be marked deferred and will not be attempted again by
   ``send_mail``.
+
+* ``runmailer`` similar to ``send_mail``, but will keep running and checking the
+  database for new messages each ``MAILER_EMPTY_QUEUE_SLEEP`` (default: 30) seconds.
+  Can be used *instead* of ``send_mail`` to circumvent the maximum frequency
+  of once per minutes inherent to cron.
 
 * ``retry_deferred`` will move any deferred mail back into the normal queue
   (so it will be attempted again on the next ``send_mail``).
@@ -102,7 +107,12 @@ this command from the virtualenv. The same, naturally, applies also if you're
 executing it with cron. The `Pinax documentation`_ explains that in more
 details.
 
+If you intend to use ``manage.py runmailer`` instead of ``send_mail`` it's
+up to you to keep this command running in the background. This can be achieved
+using `supervisord`_ or similar software.
+
 .. _pinax documentation: http://pinaxproject.com/docs/dev/deployment.html#sending-mail-and-notices
+.. _supervisord: http://supervisord.org/
 
 Controlling the delivery process
 ================================

--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -267,7 +267,7 @@ def send_loop():
     """
 
     while True:
-        while not Message.objects.all():
+        while not Message.objects.all().exists():
             logger.debug("sleeping for %s seconds before checking queue again" % EMPTY_QUEUE_SLEEP)
             time.sleep(EMPTY_QUEUE_SLEEP)
         send_all()

--- a/src/mailer/management/commands/runmailer.py
+++ b/src/mailer/management/commands/runmailer.py
@@ -1,0 +1,17 @@
+import sys
+from datetime import datetime
+
+from django.core.management import BaseCommand
+
+from mailer.engine import send_loop
+
+
+class Command(BaseCommand):
+    """Start the django-mailer send loop"""
+
+    def handle(self, *args, **options):
+        self.stdout.write(datetime.now().strftime('%B %d, %Y - %X'))
+        self.stdout.write('Starting django-mailer send loop.')
+        quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
+        self.stdout.write('Quit the loop with %s.' % quit_command)
+        send_loop()


### PR DESCRIPTION
Add the `runmailer` management command that starts the `send_loop` function already available in `mailer.engine`.

Closes #136.

