### PR TITLE
Log errors with level error

### DIFF
--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -133,7 +133,7 @@ def handle_delivery_exception(connection, message, exc):
                         smtplib.SMTPSenderRefused,
                         socket_error)):
         message.defer()
-        logger.info("message deferred due to failure: %s" % exc)
+        logger.error("message deferred due to failure: %s" % exc)
         MessageLog.objects.log(message, RESULT_FAILURE, log_message=str(exc))
 
         connection = None  # i.e. enforce creation of a new connection


### PR DESCRIPTION
We missed a critical configuration change (mailserver password had changed) last week and didn't notice until end users started complaining about not receiving mail. It took a while for us to figure out what the culprit was, luckily the error message is stored in the log table. However, it would be better if deliverability errors were logged with a higher log level so our error tracking system (Sentry) could've picked them up and alerted us.

It might be possible to use `logger.exception` here, but I'm not 100% sure. 