### PR TITLE
Add attachment integrated features

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,14 @@ There is also a convenience function ``mailer.send_html_mail`` for creating HTML
 
     send_html_mail(subject, message_plaintext, message_html, settings.DEFAULT_FROM_EMAIL, recipients)
 
+You can attach a file as a standard attachment with (specific function to keep the Django send_mail() compatibility)::
+
+    send_attachment_mail(subject, message_body, settings.DEFAULT_FROM_EMAIL, recipients, attachment_filename, attachment, attachment_content_type)
+
+or with HTML mail, with send_html_mail() and attachment parameters::
+
+    send_html_mail(subject, message_plaintext, message_html, settings.DEFAULT_FROM_EMAIL, recipients, attachment, attachment_filename, attachment_content_type)
+
 Additionally you can send all the admins as specified in the ``ADMIN``
 setting by calling::
 

--- a/src/mailer/__init__.py
+++ b/src/mailer/__init__.py
@@ -41,7 +41,7 @@ def send_mail(subject, message, from_email, recipient_list, priority=None,
     return 1
 
 def send_attachment_mail(subject, message, from_email, recipient_list,
-                   attachment_filename, attachment,
+                   attachment_filename, attachment, attachment_content_type=None,
                    priority=None, fail_silently=False, auth_user=None,
                    auth_password=None):
     """
@@ -64,7 +64,10 @@ def send_attachment_mail(subject, message, from_email, recipient_list,
 
     # We have here the EmailMessage class
     email = msg.email
-    email.attach(attachment_filename, attachment)
+    if attachment_content_type == None:
+        email.attach(attachment_filename, attachment)
+    else:
+        email.attach(attachment_filename, attachment, attachment_content_type)
     msg.email = email
     msg.save()
     return 1

--- a/src/mailer/__init__.py
+++ b/src/mailer/__init__.py
@@ -75,7 +75,8 @@ def send_attachment_mail(subject, message, from_email, recipient_list,
 
 def send_html_mail(subject, message, message_html, from_email, recipient_list,
                    priority=None, fail_silently=False, auth_user=None,
-                   auth_password=None, headers={}):
+                   auth_password=None, headers={},
+                   attachment=None, attachment_filename=None, attachment_content_type=None):
     """
     Function to queue HTML e-mails
     """
@@ -94,6 +95,8 @@ def send_html_mail(subject, message, message_html, from_email, recipient_list,
                        from_email=from_email,
                        to=recipient_list,
                        priority=priority)
+
+    # Attach alternative
     email = msg.email
     email = EmailMultiAlternatives(
         email.subject,
@@ -103,6 +106,15 @@ def send_html_mail(subject, message, message_html, from_email, recipient_list,
         headers=headers
     )
     email.attach_alternative(message_html, "text/html")
+
+    # Attach file attachment
+    if attachment and attachment_filename:
+        if attachment_content_type == None:
+            email.attach(attachment_filename, attachment)
+        else:
+            email.attach(attachment_filename, attachment, attachment_content_type)
+
+    # Publish msg
     msg.email = email
     msg.save()
     return 1

--- a/src/mailer/__init__.py
+++ b/src/mailer/__init__.py
@@ -40,6 +40,35 @@ def send_mail(subject, message, from_email, recipient_list, priority=None,
                  priority=priority).save()
     return 1
 
+def send_attachment_mail(subject, message, from_email, recipient_list,
+                   attachment_filename, attachment,
+                   priority=None, fail_silently=False, auth_user=None,
+                   auth_password=None):
+    """
+    Function to queue text e-mails with attachments
+    """
+    from django.utils.encoding import force_text
+    from mailer.models import make_message
+
+    priority = get_priority(priority)
+
+    # need to do this in case subject used lazy version of ugettext
+    subject = force_text(subject)
+    message = force_text(message)
+
+    msg = make_message(subject=subject,
+                       body=message,
+                       from_email=from_email,
+                       to=recipient_list,
+                       priority=priority)
+
+    # We have here the EmailMessage class
+    email = msg.email
+    email.attach(attachment_filename, attachment)
+    msg.email = email
+    msg.save()
+    return 1
+
 
 def send_html_mail(subject, message, message_html, from_email, recipient_list,
                    priority=None, fail_silently=False, auth_user=None,


### PR DESCRIPTION
Changes proposed in this PR:

- Added attachment options for HTML mails in send_html_mail()
- Added attachment function for plaintext mail : send_attachment_mail()

Plaintext attachment feature is in a specific function in order to keep the Django standard send_mail() syntax unchanged.

I'm not confident with your unit tests system/writing. Can someone guide me on how to write it?

