### PR TITLE
fix for expected str instance, NoneType found 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ ADDITIONAL CONTRIBUTORS include:
     * Paul Brown
     * Sebastian Pipping
     * Jaap Roes
+    * Ed Davison

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+2.2.1 - 2022-09-15
+------------------
+
+* Add fix for email address that is a NoneType
+
 2.2 - 2022-03-11
 ----------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Change log
 ==========
 
-2.2.1 - 2022-09-15
+2.2.1 - unreleased
 ------------------
 
 * Add fix for email address that is a NoneType

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-mailer",
-    version="2.2",
+    version="2.2.1",
     description="A reusable Django app for queuing the sending of email",
     long_description="""``django-mailer`` is a reusable Django app for queuing the sending of email.
 It works by storing email in the database for later sending.

--- a/src/mailer/engine.py
+++ b/src/mailer/engine.py
@@ -224,7 +224,7 @@ def send_all():
                         connection = get_connection(backend=mailer_email_backend)
                     logger.info("sending message '{0}' to {1}".format(
                         message.subject,
-                        ", ".join(message.to_addresses))
+                        ", ".join(map(str, message.to_addresses)))
                     )
                     email = message.email
                     if email is not None:


### PR DESCRIPTION
Closes: #149 

Error encountered:

```
  File "/home/otcomm/otcomm/otcommenv/lib/python3.9/site-packages/mailer/engine.py", line 191, in send_all
    ", ".join(message.to_addresses))
TypeError: sequence item 1: expected str instance, NoneType found
```

Changes proposed in this PR:

- fix situation where email address is None when submitted from Django view to django-mailer

**Tips for an ideal PR**
* You have read our Code of Conduct: https://github.com/pinax/.github/blob/master/CODE_OF_CONDUCT.md
* You have read our Contributing info: https://github.com/pinax/.github/blob/master/CONTRIBUTING.md
* The PR is atomic
* Unit tests have been updated/added, if needed
* App version number has been updated in `setup.py` (Pinax uses [SemVer](https://semver.org/))
* `Change Log` has been updated
* You have added your name to the `AUTHORS` file

