### PR TITLE
Update test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,12 @@ jobs:
           django-version: 4.0.3
         - python-version: "3.10"
           django-version: 4.0.3
+        - python-version: "3.10"
+          django-version: 4.1.9
+        - python-version: "3.10"
+          django-version: 4.2.2
+        - python-version: "3.11"
+          django-version: 4.2.2
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,8 @@ jobs:
       matrix:
         # Sync with tox.ini
         include:
-        - python-version: 2.7
-          django-version: 1.11.29
-        - python-version: 3.5
-          django-version: 2.0.13
-        - python-version: 3.6
-          django-version: 2.0.13
         - python-version: 3.7
-          django-version: 2.1.15
+          django-version: 2.2.19
         - python-version: 3.8
           django-version: 2.2.19
         - python-version: 3.9

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Change log
 ------------------
 
 * Add fix for email address that is a NoneType
+* Stop testing on unsupported Python (<3.7) and Django (<2.2) versions
+* Start testing on Python 3.11 and Django 4.1/4.2
 
 2.2 - 2022-03-11
 ----------------

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist =
     py37-django22-test,
     py38-django22-test,
     py39-django{30,31,32,40}-test,
-    py310-django40-test,
+    py310-django{40,41,42}-test,
+    py311-django42-test,
     flake-py39-django32,
     checkmanifest-py39,
 
@@ -34,3 +35,5 @@ deps =
     django31: Django==3.1.12
     django32: Django==3.2.4
     django40: Django==4.0.3
+    django41: Django==4.1.9
+    django42: Django==4.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 # Remember to add to .github/workflows/build.yml if this is added to.
 envlist =
     # Not every combination, just a representative sample:
-    py27-django111-test,
-    {py35,py36}-django20-test,
-    py37-django21-test,
+    py37-django22-test,
     py38-django22-test,
     py39-django{30,31,32,40}-test,
     py310-django40-test,
@@ -31,9 +29,6 @@ deps =
     -e .
     flake8: -r requirements-dev.txt
     checkmanifest: -r requirements-dev.txt
-    django111: Django==1.11.29
-    django20: Django==2.0.13
-    django21: Django==2.1.15
     django22: Django==2.2.19
     django30: Django==3.0.14
     django31: Django==3.1.12


### PR DESCRIPTION
As noted in https://github.com/pinax/django-mailer/pull/164#issuecomment-1577436828, support for unsupported versions can be dropped.

This PR removes unsupported versions from the test matrix, and adds recent versions of Django and Python.