### PR TITLE
Fix condition for deprecated '--cron' argument in "send_mail" command

### DIFF
--- a/src/mailer/management/commands/send_mail.py
+++ b/src/mailer/management/commands/send_mail.py
@@ -17,7 +17,7 @@ class Command(CronArgMixin, BaseCommand):
     help = "Do one pass through the mail queue, attempting to send all mail."
 
     def handle(self, *args, **options):
-        if options["cron"] == 0:
+        if options["cron"]:
             warnings.warn(
                 "send_mail's -c/--cron option is no longer " "necessary and will be removed in a future release",
                 DeprecationWarning,


### PR DESCRIPTION
Fix logic for the condition to issue a warning about the deprecated '--cron' argument in the "send_mail" command. The "retry_deferred" command seems to have already the correct check.

P.S.: great package, thank you.