### PR TITLE
Switch from lockfile to filelock

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ ADDITIONAL CONTRIBUTORS include:
     * Jaap Roes
     * Ed Davison
     * Sander Smits
+    * Steve Kowalik

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir = =src
 python_requires = >=3.8
 install_requires =
     Django >= 2.2
-    lockfile >= 0.8
+    filelock >= 3.5
 
 [options.packages.find]
 where = src

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py39-django{30,31,32,40}-test,
     py310-django{40,41,42}-test,
     py311-django42-test,
+    py312-django42-test,
     flake-py39-django32,
     checkmanifest-py39,
 
@@ -15,6 +16,7 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 
 commands =
     test: pytest --cov=mailer


### PR DESCRIPTION
lockfile has been declared unmaintained[1], switch to using filelock to perform the same locking operations. Drive by adding Python 3.12 support to tox.ini.

1: https://github.com/openstack-archive/pylockfile