### PR TITLE
Add purge_deferred management command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ ADDITIONAL CONTRIBUTORS include:
     * Jaap Roes
     * Ed Davison
     * Sander Smits
+    * John Beeler

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Change log
 ==========
 
+2.3.3 - 2025-05-31
+------------------
+
+* Added ``purge_deferred`` management command to purge deferred messages, thanks @thorrak.
+
+
 2.3.2 - 2024-05-22
 ------------------
 

--- a/src/mailer/__init__.py
+++ b/src/mailer/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 
 
 def get_priority(priority):

--- a/src/mailer/management/commands/purge_deferred.py
+++ b/src/mailer/management/commands/purge_deferred.py
@@ -1,0 +1,22 @@
+import logging
+import warnings
+
+from django.core.management.base import BaseCommand
+
+from mailer.management.helpers import CronArgMixin
+from mailer.models import Message
+
+logger = logging.getLogger(__name__)
+
+
+class Command(CronArgMixin, BaseCommand):
+    help = "Purge any deferred mail."
+
+    def handle(self, *args, **options):
+        if options["cron"]:
+            warnings.warn(
+                "purge_deferred's -c/--cron option is no longer necessary and will be removed in a future release",
+                DeprecationWarning,
+            )
+        count = Message.objects.purge_deferred()
+        logger.info(f"{count} message(s) purged")

--- a/src/mailer/models.py
+++ b/src/mailer/models.py
@@ -81,6 +81,12 @@ class MessageManager(models.Manager):
             qs = qs.filter(retry_count__lt=settings.MAILER_EMAIL_MAX_RETRIES)
         return qs.update(priority=new_priority, retry_count=models.F("retry_count") + 1)
 
+    def purge_deferred(self):
+        qs = self.deferred()
+        count = qs.count()
+        qs.delete()
+        return count
+
 
 base64_encode = base64.encodebytes if hasattr(base64, "encodebytes") else base64.encodestring
 base64_decode = base64.decodebytes if hasattr(base64, "decodebytes") else base64.decodestring


### PR DESCRIPTION
This PR adds a new `purge_deferred` Django management command which purges any deferred messages.

This is intended for a scenario where you have had an authentication/connectivity issue with the mail server, and messages have backed up in the queue that you no longer want to send.

This PR updates the version number to **2.3.3**.