### PR TITLE
Suppress KeyboardInterrupt in command

### DIFF
--- a/src/mailer/management/commands/runmailer.py
+++ b/src/mailer/management/commands/runmailer.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from argparse import ArgumentParser
+from contextlib import suppress
 from datetime import datetime
 
 from django.core.management import BaseCommand
@@ -27,4 +28,5 @@ class Command(BaseCommand):
         self.stdout.write("Starting django-mailer send loop.")
         quit_command = "CTRL-BREAK" if sys.platform == "win32" else "CONTROL-C"
         self.stdout.write(f"Quit the loop with {quit_command}.")
-        send_loop()
+        with suppress(KeyboardInterrupt):
+            send_loop()

--- a/src/mailer/management/commands/runmailer_pg.py
+++ b/src/mailer/management/commands/runmailer_pg.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from argparse import ArgumentParser
+from contextlib import suppress
 from datetime import datetime
 
 from django.core.management import BaseCommand
@@ -28,4 +29,5 @@ class Command(BaseCommand):
         self.stdout.write("Starting django-mailer send loop.")
         quit_command = "CTRL-BREAK" if sys.platform == "win32" else "CONTROL-C"
         self.stdout.write(f"Quit the loop with {quit_command}.")
-        postgres_send_loop()
+        with suppress(KeyboardInterrupt):
+            postgres_send_loop()


### PR DESCRIPTION
Changes proposed in this PR:

- Suppress `KeyboardInterrupt` in the `runmailer` and `runmailer_pg` commands to prevent console errors when stopping the loop with `CTRL-BREAK`.
